### PR TITLE
Implemented atom type arrays to ease post-simulation analysis

### DIFF
--- a/pymatgen/io/openmm/sets.py
+++ b/pymatgen/io/openmm/sets.py
@@ -46,7 +46,7 @@ class OpenMMSet(InputSet):
     ):
         """
         Instantiates an InputSet from a directory containing a Topology PDB, a
-        System XML, a Integrator XML, and (optionally) a State XML. If no State
+        System XML, an Integrator XML, and (optionally) a State XML. If no State
         is given, system coordinates must be manually assigned.
 
         Args:


### PR DESCRIPTION
This will add `atom_type.npy` and `atom_resname.npy` array files to the InputSet object. These are intended to overwrite the default MDAnalysis `type` and `resname` AtomGroup attributes, which are not useful when generated from OpenMM dcd files.

In particular, the `atom_type` array will associate a unique number with each unique atom in the molecule and the `resname` array will associate a residue name with each atom in the molecule.

The addition of these arrays will ease post-simulation analysis.